### PR TITLE
feat: function-cache

### DIFF
--- a/packages.nix
+++ b/packages.nix
@@ -1759,6 +1759,25 @@ in
     ];
   };
 
+  function-cache = lispDerivation {
+    lispSystems = [ "function-cache" ];
+    src = sources.function-cache;
+    lispDependencies = [
+      alexandria
+      cl-interpol
+      iterate
+      symbol-munger
+      closer-mop
+    ];
+
+    lispCheckDependencies = [ lisp-unit2 ];
+
+    meta.broken =
+      # Supported lisps: sbcl clozure
+      self._lisp.name != "sbcl" && self._lisp.name != "ccl";
+
+  };
+
   garbage-pools = lispDerivation {
     lispSystem = "garbage-pools";
     src = sources.garbage-pools;

--- a/packages.nix
+++ b/packages.nix
@@ -1760,7 +1760,7 @@ in
   };
 
   function-cache = lispDerivation {
-    lispSystems = [ "function-cache" ];
+    lispSystem = "function-cache";
     src = sources.function-cache;
     lispDependencies = [
       alexandria

--- a/sources/flake.lock
+++ b/sources/flake.lock
@@ -1848,6 +1848,22 @@
         "type": "github"
       }
     },
+    "function-cache": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687269629,
+        "narHash": "sha256-3IxAh/VrvoahiV8yT5gCduk5668chX1/6tPwf5orY+o=",
+        "owner": "AccelerationNet",
+        "repo": "function-cache",
+        "rev": "f20e3cd2a24420d7a999747183cb573d14ebc36f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "AccelerationNet",
+        "repo": "function-cache",
+        "type": "github"
+      }
+    },
     "garbage-pools": {
       "flake": false,
       "locked": {
@@ -3292,6 +3308,7 @@
         "float-features": "float-features",
         "form-fiddle": "form-fiddle",
         "fset": "fset",
+        "function-cache": "function-cache",
         "garbage-pools": "garbage-pools",
         "gettext": "gettext",
         "global-vars": "global-vars",

--- a/sources/flake.nix
+++ b/sources/flake.nix
@@ -533,6 +533,10 @@
       url = "github:slburson/fset";
       flake = false;
     };
+    function-cache = {
+      url = "github:AccelerationNet/function-cache";
+      flake = false;
+    };
     garbage-pools = {
       url = "github:archimag/garbage-pools";
       flake = false;


### PR DESCRIPTION
I'm exploring memoization for a small project and found a slight lack in the package availability :)

Add:
- [fare-memoization](https://gitlab.common-lisp.net/frideau/fare-memoization)
- [function-cache](https://github.com/AccelerationNet/function-cache/tree/master)

<!--

  Thank you for opening a pull request.  I accept contributions to cl-nix-lite
  which are released in the “public domain.”

  This is *NOT A CLA*: you remain the author and copyright holder of this piece
  of code.  You just agree to grant everyone the rights to use it under the CC0
  license.

-->

**By submiting this PR, I agree to license this contribution under Creative Commons’ [CC0 license](https://creativecommons.org/public-domain/cc0/).**